### PR TITLE
fix order of label and loop_coalesce

### DIFF
--- a/hls4ml/templates/quartus/firmware/nnet_utils/nnet_padding_stream.h
+++ b/hls4ml/templates/quartus/firmware/nnet_utils/nnet_padding_stream.h
@@ -44,8 +44,8 @@ void zeropad1d_cl(stream<data_T> &data, stream<res_T> &res) {
 
 template<class data_T, class res_T, typename CONFIG_T>
 void zeropad2d_cl(stream<data_T> &data, stream<res_T> &res) {
+    PadTop:
     #pragma loop_coalesce 2
-    PadTop: 
     for (int i = 0; i < CONFIG_T::pad_top; i++) {
         PadTopWidth: 
         for (int j = 0; j < CONFIG_T::out_width; j++) {
@@ -53,8 +53,8 @@ void zeropad2d_cl(stream<data_T> &data, stream<res_T> &res) {
         }
     }
 
+    PadMain:
     #pragma loop_coalesce 2
-    PadMain: 
     for (int i = 0; i < CONFIG_T::in_height; i++) {
         
         PadLeft: 


### PR DESCRIPTION
# Description

This is a bug fix to fix problems like:

```
In file included from ./firmware/parameters.h:11:
./firmware/nnet_utils/nnet_padding_stream.h:48:5: error: expected a for, while, or do-while loop to follow '#pragma loop_coalesce'
    PadTop: 
    ^
./firmware/nnet_utils/nnet_padding_stream.h:57:5: error: expected a for, while, or do-while loop to follow '#pragma loop_coalesce'
    PadMain: 
    ^
2 errors generated.
HLS Testbench parse FAILED.

```
## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Tests

A model created by:

```python
class TestModel :

    def build(self , inputs) :
        # contracting path
        i1 = keras.layers.Reshape ( target_shape = (10 , 1) , name = "adjustedInputs" ) ( inputs )
        u1 = keras.layers.ZeroPadding1D ( padding = (15 , 0) , name = "zeropadding2" ) ( i1 )
        u2 = keras.layers.Concatenate ( axis = -1 ) ( [u1 , u1] )
        out = keras.layers.Reshape ( target_shape = (50 , 1) , name = "output" ) ( u2 )
        return out

    def assemble_model(self , input_dim) :
        inputs = keras.layers.Input ( shape = input_dim , name = "inputLayer" )
        outputs = self.build ( inputs )
        model = keras.models.Model ( inputs = inputs , outputs = outputs , name = "model" )
        print ( model.summary ( ) )
        return model
```
produces the above error when synthesizing.

## Checklist

- [x] I have read the [guidelines for contributing](https://github.com/fastmachinelearning/hls4ml/blob/main/CONTRIBUTING.md).

- [x] My changes generate no new warnings.
