### PR TITLE
Reduce AXI utils resources

### DIFF
--- a/hls4ml/templates/coyote_accelerator/nnet_utils/nnet_axi_utils.h
+++ b/hls4ml/templates/coyote_accelerator/nnet_utils/nnet_axi_utils.h
@@ -6,85 +6,69 @@
 namespace nnet {
 
 // Converts an array of data (fixed-point numbers) into 512-bit AXI stream packets; see model_wrapper.hpp for usage
-template <class array_T, class axi_T, unsigned int SIZE, unsigned int AXI_BITS, unsigned int PRECISION> 
+template <class array_T, class axi_T, unsigned int SIZE, unsigned int AXI_BITS, unsigned int PRECISION>
 void data_to_axi_stream(array_T data_in[SIZE], hls::stream<ap_axiu<AXI_BITS, 0, 0, 0>> &axi_out) {
     #pragma HLS INLINE OFF
-    #pragma HLS PIPELINE
 
     constexpr const unsigned int ELEMENTS_PER_AXI = AXI_BITS / PRECISION;
     constexpr const unsigned int NUM_BEATS = (SIZE + ELEMENTS_PER_AXI - 1) / ELEMENTS_PER_AXI;
 
     for (unsigned int i = 0; i < NUM_BEATS; i++) {
-        if (i == NUM_BEATS - 1) {
-            ap_axiu<AXI_BITS, 0, 0, 0> axi_packet;
-            unsigned int index = i * ELEMENTS_PER_AXI;
+        #pragma HLS PIPELINE II = 1
 
-            for (unsigned int j = 0; j < SIZE - index; j++) {
-                #pragma HLS UNROLL
-                
+        ap_axiu<AXI_BITS, 0, 0, 0> axi_packet;
+        axi_packet.data = 0;
+        unsigned int index = i * ELEMENTS_PER_AXI;
+
+        for (unsigned int j = 0; j < ELEMENTS_PER_AXI; j++) {
+            #pragma HLS UNROLL
+
+            if (index + j < SIZE) {
                 axi_T axi_tmp = axi_T(data_in[index + j]);
-                ap_uint<PRECISION> axi_bits = *reinterpret_cast<ap_uint<PRECISION>*>(&axi_tmp);
+                ap_uint<PRECISION> axi_bits = *reinterpret_cast<ap_uint<PRECISION> *>(&axi_tmp);
                 axi_packet.data.range((j + 1) * PRECISION - 1, j * PRECISION) = axi_bits;
             }
-
-            axi_packet.last = 1;
-            axi_out.write(axi_packet);
-
-        } else {
-            ap_axiu<AXI_BITS, 0, 0, 0> axi_packet;
-            unsigned int index = i * ELEMENTS_PER_AXI;
-            
-            for (unsigned int j = 0; j < ELEMENTS_PER_AXI; j++) {
-                #pragma HLS UNROLL
-                
-                axi_T axi_tmp = axi_T(data_in[index + j]);
-                ap_uint<PRECISION> axi_bits = *reinterpret_cast<ap_uint<PRECISION>*>(&axi_tmp);
-                axi_packet.data.range((j + 1) * PRECISION - 1, j * PRECISION) = axi_bits;
-            }
-
-            axi_packet.last = 0;
-            axi_out.write(axi_packet);
         }
+        axi_packet.last = (i == NUM_BEATS - 1) ? 1 : 0;
+        axi_out.write(axi_packet);
     }
 }
 
 // Unpacks beats of 512-bit AXI beats into an array of data (fixed-point numbers) see model_wrapper.hpp for usage
-template <class array_T, class axi_T, unsigned int SIZE, unsigned int AXI_BITS, unsigned int PRECISION> 
+template <class array_T, class axi_T, unsigned int SIZE, unsigned int AXI_BITS, unsigned int PRECISION>
 void axi_stream_to_data(hls::stream<ap_axiu<AXI_BITS, 0, 0, 0>> &axi_in, array_T data_out[SIZE]) {
     #pragma HLS INLINE OFF
-    #pragma HLS PIPELINE
 
     constexpr const unsigned int ELEMENTS_PER_AXI = AXI_BITS / PRECISION;
     constexpr const unsigned int NUM_BEATS = (SIZE + ELEMENTS_PER_AXI - 1) / ELEMENTS_PER_AXI;
 
+    array_T data_buffer[SIZE];
+    #pragma HLS ARRAY_PARTITION variable = data_buffer complete
+
+    // Collect all items from stream into the buffer
     for (unsigned int i = 0; i < NUM_BEATS; i++) {
-        if (i == NUM_BEATS - 1) {
-            unsigned int index = i * ELEMENTS_PER_AXI;
-            ap_axiu<AXI_BITS, 0, 0, 0> axi_packet = axi_in.read();
+        #pragma HLS PIPELINE II = 1
 
-            for (unsigned int j = 0; j < SIZE - index; j++) {
-                #pragma HLS UNROLL
-                    
+        unsigned int index = i * ELEMENTS_PER_AXI;
+        ap_axiu<AXI_BITS, 0, 0, 0> axi_packet = axi_in.read();
+
+        for (unsigned int j = 0; j < ELEMENTS_PER_AXI; j++) {
+            #pragma HLS UNROLL
+
+            if (index + j < SIZE) {
                 ap_uint<PRECISION> axi_bits = axi_packet.data.range((j + 1) * PRECISION - 1, j * PRECISION);
-                axi_T axi_tmp = *reinterpret_cast<axi_T*>(&axi_bits);
-                data_out[index + j] = array_T(axi_tmp);
-            }
-
-        } else {
-            unsigned int index = i * ELEMENTS_PER_AXI;
-            ap_axiu<AXI_BITS, 0, 0, 0> axi_packet = axi_in.read();
-
-            for (unsigned int j = 0; j < ELEMENTS_PER_AXI; j++) {
-                #pragma HLS UNROLL
-                    
-                ap_uint<PRECISION> axi_bits = axi_packet.data.range((j + 1) * PRECISION - 1, j * PRECISION);
-                axi_T axi_tmp = *reinterpret_cast<axi_T*>(&axi_bits);
-                data_out[index + j] = array_T(axi_tmp);
+                axi_T axi_tmp = *reinterpret_cast<axi_T *>(&axi_bits);
+                data_buffer[index + j] = array_T(axi_tmp);
             }
         }
     }
-}
 
+    // Now write everything out in parallel
+    for (unsigned int i = 0; i < SIZE; i++) {
+        #pragma HLS UNROLL
+        data_out[i] = data_buffer[i];
+    }
 }
+} // namespace nnet
 
 #endif

--- a/hls4ml/templates/coyote_accelerator/nnet_utils/nnet_axi_utils_stream.h
+++ b/hls4ml/templates/coyote_accelerator/nnet_utils/nnet_axi_utils_stream.h
@@ -6,72 +6,78 @@
 namespace nnet {
 
 // Converts an stream of data (fixed-point numbers) into 512-bit AXI stream packets; see model_wrapper.hpp for usage
-template <class array_T, class axi_T, unsigned int SIZE, unsigned int AXI_BITS, unsigned int PRECISION> 
+template <class array_T, class axi_T, unsigned int SIZE, unsigned int AXI_BITS, unsigned int PRECISION>
 void data_to_axi_stream(hls::stream<array_T> &data_in, hls::stream<ap_axiu<AXI_BITS, 0, 0, 0>> &axi_out) {
     #pragma HLS INLINE OFF
-    #pragma HLS PIPELINE
 
     constexpr const unsigned int ELEMENTS_PER_AXI = (SIZE <= (AXI_BITS / PRECISION)) ? SIZE : (AXI_BITS / PRECISION);
-    constexpr const unsigned int NUM_BEATS = SIZE / ELEMENTS_PER_AXI + (SIZE % ELEMENTS_PER_AXI != 0);
 
     unsigned int index = 0;
+    unsigned int total_elements_processed = 0;
     ap_axiu<AXI_BITS, 0, 0, 0> axi_packet;
 
     for (int i = 0; i < SIZE / array_T::size; i++) {
+        #pragma HLS PIPELINE II = 1
+
         array_T in_data = data_in.read();
 
         for (int j = 0; j < array_T::size; j++) {
-            #pragma HLS UNROLL    
-            axi_T axi_tmp = axi_T (in_data[j]);
-            ap_uint<PRECISION> axi_bits = *reinterpret_cast<ap_uint<PRECISION>*>(&axi_tmp);
+            #pragma HLS UNROLL
+
+            axi_T axi_tmp = axi_T(in_data[j]);
+            ap_uint<PRECISION> axi_bits = *reinterpret_cast<ap_uint<PRECISION> *>(&axi_tmp);
             axi_packet.data.range((index + 1) * PRECISION - 1, index * PRECISION) = axi_bits;
             index++;
-            if (index == ELEMENTS_PER_AXI) {
-                axi_packet.last = 0;
+            total_elements_processed++;
+
+            if (index == ELEMENTS_PER_AXI || total_elements_processed == SIZE) {
+                axi_packet.last = (total_elements_processed == SIZE) ? 1 : 0;
                 axi_out.write(axi_packet);
                 index = 0;
+                axi_packet.data = 0;
             }
         }
     }
-
-    if (index != ELEMENTS_PER_AXI && index != 0) {
-        axi_packet.last = 1;
-        axi_out.write(axi_packet);
-    }
-
 }
 
 // Unpacks beats of 512-bit AXI beats into an stream of data (fixed-point numbers) see model_wrapper.hpp for usage
-template <class array_T, class axi_T, unsigned int SIZE, unsigned int AXI_BITS, unsigned int PRECISION> 
+template <class array_T, class axi_T, unsigned int SIZE, unsigned int AXI_BITS, unsigned int PRECISION>
 void axi_stream_to_data(hls::stream<ap_axiu<AXI_BITS, 0, 0, 0>> &axi_in, hls::stream<array_T> &data_out) {
     #pragma HLS INLINE OFF
-    #pragma HLS PIPELINE
 
     constexpr const unsigned int ELEMENTS_PER_AXI = (SIZE <= (AXI_BITS / PRECISION)) ? SIZE : (AXI_BITS / PRECISION);
     constexpr const unsigned int NUM_BEATS = SIZE / ELEMENTS_PER_AXI + (SIZE % ELEMENTS_PER_AXI != 0);
 
     array_T tmp;
-    unsigned int index = 0;
-    ap_axiu<AXI_BITS, 0, 0, 0> axi_packet;
+    #pragma HLS ARRAY_PARTITION variable=tmp complete
+
+    unsigned int pack_index = 0;
 
     for (int i = 0; i < NUM_BEATS; i++) {
+        #pragma HLS PIPELINE II = 1
+
         ap_axiu<AXI_BITS, 0, 0, 0> axi_packet = axi_in.read();
-    
+
+        unsigned int boundary_index = i * ELEMENTS_PER_AXI;
+
         for (int j = 0; j < ELEMENTS_PER_AXI; j++) {
             #pragma HLS UNROLL
-            ap_uint<PRECISION> axi_bits = axi_packet.data.range((j + 1) * PRECISION - 1, j * PRECISION);
-            axi_T axi_tmp = *reinterpret_cast<axi_T*>(&axi_bits);
-            tmp[index] = typename array_T::value_type(axi_tmp);
-            index++;
-            if (index == array_T::size) {
-                index = 0;
-                data_out.write(tmp);
-    
+
+            if (boundary_index + j < SIZE) {
+                ap_uint<PRECISION> axi_bits = axi_packet.data.range((j + 1) * PRECISION - 1, j * PRECISION);
+                axi_T axi_tmp = *reinterpret_cast<axi_T *>(&axi_bits);
+                tmp[pack_index] = typename array_T::value_type(axi_tmp);
+
+                pack_index++;
+                if (pack_index == array_T::size) {
+                    pack_index = 0;
+                    data_out.write(tmp);
+                }
             }
         }
     }
 }
 
-}
+} // namespace nnet
 
 #endif


### PR DESCRIPTION
# Description

I have noticed that the `nnet_axi_utils.h`, `nnet_axi_utils_stream.h` templates contain a `#pragma HLS PIPELINE` at the top of the functions, which causes Vitis HLS to fully unroll loops in the subsequent blocks. When operating on streams however, fully unrolling does not make much sense imo, since data can only be read sequentially (instead of in parallel).

Also, some of the functions contain variable loop bounds (e.g. [here](https://github.com/bo3z/hls4ml/blob/coyote-accelerator/hls4ml/templates/coyote_accelerator/nnet_utils/nnet_axi_utils.h#L22)), which might make it harder for Vitis to optimize ([ref](https://docs.amd.com/r/en-US/ug1399-vitis-hls/Working-with-Variable-Loop-Bounds)). 

I have tested my changes with hls4ml implementations of [GravNet](https://github.com/morunner/hls4ml-gravnet/tree/dev) and a smaller version of [GarNet](https://github.com/morunner/hls4ml-garnet-lite/tree/dev) using a [branch](https://github.com/morunner/hls4ml/tree/coyote-accelerator/reduce-axi-utils-resources) on my own fork of hls4ml, which includes the proposed changes. With these, both networks pass PnR and achieve the desired accuracies when running inference with Coyote on the Alveo u55c accelerator card.

Here are some numbers of resource utilizations taken from `shell_utilization.rpt` after PnR, before/after the changes:

Before:
| Network       | I/O Type    | LUT  | FF   | DSP  | BRAM |
|---------------|-------------|------|------|------|------|
| GarNet (Lite) | io_parallel | N/A* | N/A* | N/A* | N/A* |
| GravNet       | io_stream   | 53%  | 17%  | 14%  | 18%  |

\* Haven't been able to run PnR for this model. Vivado aborted reporting high global congestion level 7.

After:
| Network       | I/O Type    | LUT | FF  | DSP | BRAM |
|---------------|-------------|-----|-----|-----|------|
| GarNet (Lite) | io_parallel | 23% | 15% | 15% | 8%   |
| GravNet       | io_stream   | 36% | 15% | 14% | 18%  |

## Type of change

- [x] Improvement