### PR TITLE
CoyoteAccelerator: fix dtype check in CoyoteOverlay

### DIFF
--- a/hls4ml/backends/coyote_accelerator/coyote_accelerator_overlay.py
+++ b/hls4ml/backends/coyote_accelerator/coyote_accelerator_overlay.py
@@ -62,7 +62,7 @@ class CoyoteOverlay:
         """
         if len(X.shape) == 1:
             X = np.array([X])
-        if not (isinstance(X.dtype, float) or isinstance(X.dtype, np.float32)):
+        if not np.issubdtype(X.dtype, np.floating):
             logging.warning('CoyoteOverlay only supports (for now) floating-point inputs; casting input data to float')
             X = X.astype(np.float32)
         y = np.empty((len(X), *y_shape))


### PR DESCRIPTION
# Description

Fixes warning in dtype input validation in `CoyoteOverlay.predict`.

The previous check used `isinstance(X.dtype, ...)`, but `X.dtype` is a `numpy.dtype` object and therefore floating NumPy dtypes were not detected correctly.

Use `np.issubdtype(X.dtype, np.floating)` to detect floating inputs and avoid triggering the warning unnecessarily.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
